### PR TITLE
Add Multi language support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Here are some attributes that you could change. keep in mind that the controller
 ```dart
 BuiltInKeyboard(
   controller: this.textController, // required
-  layoutType: 'EN', // required, Only QWERTY and AZERTY are currently available
+  language: Language.DE, // optional
+  layout: Layout.QWERTZ, // optional, BUT MUST be checked if you modify the language!
   enableSpaceBar: true, // optional, add a spacebar
   enableBackSpace: true, // optional, add a backspace button
   enableCapsLock: true, // optional, add a Caps Lock button
@@ -34,7 +35,8 @@ BuiltInKeyboard(
 Option | Required | By default | Description
 --- | --- | --- | ---
 **controller** | yes | - | `TextEditingController`
-**layoutType** | yes | - | the layout of the keyboard
+**language** | no | Language.EN | the language of the keyboard
+**layout** | no | Layout.QWERTY | the layout of the keyboard
 **height** | no | - | height of keys
 **width** | no | - | width of keys
 **spacing** | no | 8.0 | the spacing between each row
@@ -48,3 +50,64 @@ Option | Required | By default | Description
 **enableLongPressUppercase** | no | false | writes an uppercase when long pressing on the keys
 **highlightColor** | no | - | color when pressed
 **splashColor** | no | - | color when pressed (material style)
+
+## Contribution
+### Languages
+To add a new language or a keyboad layout to the package you only need to modify the language.dart file. The following steps will show you how to do that.
+
+1. Add the short name form of your new language to the `Language` enum.
+```
+enum Language {
+  EN,
+  FR,
+  DE,
+  <your new language>,
+}
+```
+2. Add your layout name to the `Layout` enum if not present.
+```
+enum Layout {
+  QWERTY,
+  QWERTZ,
+  AZERTY,
+  <new layout>,
+}
+```
+3. Create a new map variable called `<language name>Config`. The keys of this map will be the layouts from the `Layout` enum (e.g: Layout.QWERTY), and the values will be maps with types `<String, String>` that contain the core configuration. These latter maps must contain four fields o:
+   1. `layout`: The full text layout of the keyboard.
+   2. `horizontalSpacing`: A floating number which will represent the spaceing between each key. 
+   3. `topLength`: The lenght of the top/first row of keys. In other words, the number of keys to display in the top row.
+   4. `middleLength`: The number of keys in the middle row.
+
+    (The bottom/last row will just take the remaining keys).
+
+    example:
+    ```
+    var frenchConfig = {
+      Layout.QWERTY: <String, String>{
+        'layout': 'qwertyuiopasdfghjklzxcvbnm',
+        'horizontalSpacing': '6.0',
+        'topLength': '10',
+        'middleLength': '9',
+      },
+      Layout.AZERTY: <String, String>{
+        'layout': 'azertyuiopqsdfghjklmwxcvbn',
+        'horizontalSpacing': '6.0',
+        'topLength': '10',
+        'middleLength': '9',
+      },
+    };
+    ```
+4. And finally your new language config map to the `languageConfig` map, with the key as the short language name from the `Language` enum.
+```
+var languageConfig = {
+  Language.EN: englishConfig,
+  Language.FR: frenchConfig,
+  Language.DE: germanConfig,
+  Language.<short language name>: <language name>Config,
+};
+```
+
+Feel free to also modify or add new things to existing languges.
+
+

--- a/lib/built_in_keyboard.dart
+++ b/lib/built_in_keyboard.dart
@@ -1,15 +1,22 @@
 library built_in_keyboard;
 
+import 'dart:io';
+
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+
+import 'language.dart';
 
 class BuiltInKeyboard extends StatefulWidget {
   // customize user letters
   final List<String>? customLetters;
 
-  // layoutType of the keyboard
-  final String? layoutType;
+  // Language of the keyboard
+  final Language language;
+
+  // layout of the keyboard
+  final Layout layout;
 
   // The controller connected to the InputField
   final TextEditingController? controller;
@@ -49,7 +56,8 @@ class BuiltInKeyboard extends StatefulWidget {
 
   BuiltInKeyboard({
     @required this.controller,
-    @required this.layoutType,
+    this.language = Language.EN,
+    this.layout = Layout.QWERTY,
     this.height,
     this.width,
     this.spacing = 8.0,
@@ -80,22 +88,36 @@ class BuiltInKeyboardState extends State<BuiltInKeyboard> {
     height = screenHeight > 800 ? screenHeight * 0.059 : screenHeight * 0.07;
     width = screenWidth > 350 ? screenWidth * 0.084 : screenWidth * 0.082;
     List<Widget> keyboardLayout = layout();
+    double hspacing;
+    int topLen, midLen;
+    try {
+      hspacing = double.parse(languageConfig[widget.language]![widget.layout]![
+          'horizontalSpacing']!);
+      topLen = int.parse(
+          languageConfig[widget.language]![widget.layout]!['topLength']!);
+      midLen = int.parse(
+          languageConfig[widget.language]![widget.layout]!['middleLength']!);
+    } catch (_CastError) {
+      printError(
+          "Uknown language or layout was used, or Incorrect combination of language-layout");
+      exit(0);
+    }
     return Column(
       children: [
         Wrap(
           alignment: WrapAlignment.center,
-          spacing: 6,
+          spacing: hspacing,
           runSpacing: 5,
-          children: keyboardLayout.sublist(0, 10),
+          children: keyboardLayout.sublist(0, topLen),
         ),
         SizedBox(
           height: widget.spacing,
         ),
         Wrap(
           alignment: WrapAlignment.center,
-          spacing: 6,
+          spacing: hspacing,
           runSpacing: 5,
-          children: keyboardLayout.sublist(10, 19),
+          children: keyboardLayout.sublist(topLen, topLen + midLen),
         ),
         SizedBox(
           height: widget.spacing,
@@ -110,9 +132,9 @@ class BuiltInKeyboardState extends State<BuiltInKeyboard> {
                   ),
             Wrap(
               alignment: WrapAlignment.center,
-              spacing: 6,
+              spacing: hspacing,
               runSpacing: 5,
-              children: keyboardLayout.sublist(19),
+              children: keyboardLayout.sublist(topLen + midLen),
             ),
             widget.enableBackSpace
                 ? backSpace()
@@ -284,19 +306,14 @@ class BuiltInKeyboardState extends State<BuiltInKeyboard> {
 
   // Keyboard layout list
   List<Widget> layout() {
-    List<String>? letters = [];
-    if (widget.layoutType == 'EN') {
-      if (widget.enableAllUppercase || capsLockUppercase) {
-        letters = 'qwertyuiopasdfghjklzxcvbnm'.toUpperCase().split("");
-      } else {
-        letters = 'qwertyuiopasdfghjklzxcvbnm'.split("");
-      }
-    } else if (widget.layoutType == 'FR') {
-      if (widget.enableAllUppercase || capsLockUppercase) {
-        letters = 'azertyuiopqsdfghjklmwxcvbn'.toUpperCase().split("");
-      } else {
-        letters = 'azertyuiopqsdfghjklmwxcvbn'.split("");
-      }
+    List<String> letters = [];
+    try {
+      letters =
+          languageConfig[widget.language]![widget.layout]!['layout']!.split("");
+    } catch (_CastError) {
+      printError(
+          "Uknown language or layout was used, or Incorrect combination of language-layout");
+      exit(0);
     }
 
     List<Widget> keyboard = [];
@@ -307,4 +324,8 @@ class BuiltInKeyboardState extends State<BuiltInKeyboard> {
     });
     return keyboard;
   }
+}
+
+void printError(String text) {
+  print('\x1B[31m$text\x1B[0m');
 }

--- a/lib/built_in_keyboard.dart
+++ b/lib/built_in_keyboard.dart
@@ -9,9 +9,6 @@ import 'package:flutter/services.dart';
 import 'language.dart';
 
 class BuiltInKeyboard extends StatefulWidget {
-  // customize user letters
-  final List<String>? customLetters;
-
   // Language of the keyboard
   final Language language;
 
@@ -71,7 +68,6 @@ class BuiltInKeyboard extends StatefulWidget {
     this.enableLongPressUppercase = false,
     this.highlightColor,
     this.splashColor,
-    this.customLetters,
   });
   @override
   BuiltInKeyboardState createState() => BuiltInKeyboardState();

--- a/lib/language.dart
+++ b/lib/language.dart
@@ -1,6 +1,7 @@
 enum Language {
   EN,
   FR,
+  DE,
 }
 enum Layout {
   QWERTY,
@@ -11,6 +12,7 @@ enum Layout {
 var languageConfig = {
   Language.EN: englishConfig,
   Language.FR: frenchConfig,
+  Language.DE: germanConfig,
 };
 
 // Languages Configurations
@@ -42,5 +44,20 @@ var frenchConfig = {
     'horizontalSpacing': '6.0',
     'topLength': '10',
     'middleLength': '9',
+  },
+};
+
+var germanConfig = {
+  Layout.QWERTY: <String, String>{
+    'layout': 'qwertyuiopüasdfghjklöäzxcvbnmß',
+    'horizontalSpacing': '2.5',
+    'topLength': '11',
+    'middleLength': '11',
+  },
+  Layout.QWERTZ: <String, String>{
+    'layout': 'qwertzuiopüasdfghjklöäyxcvbnmß',
+    'horizontalSpacing': '2.5',
+    'topLength': '10',
+    'middleLength': '11',
   },
 };

--- a/lib/language.dart
+++ b/lib/language.dart
@@ -3,6 +3,7 @@ enum Language {
   FR,
   DE,
 }
+
 enum Layout {
   QWERTY,
   QWERTZ,

--- a/lib/language.dart
+++ b/lib/language.dart
@@ -1,0 +1,46 @@
+enum Language {
+  EN,
+  FR,
+}
+enum Layout {
+  QWERTY,
+  QWERTZ,
+  AZERTY,
+}
+
+var languageConfig = {
+  Language.EN: englishConfig,
+  Language.FR: frenchConfig,
+};
+
+// Languages Configurations
+
+var englishConfig = {
+  Layout.QWERTY: <String, String>{
+    'layout': 'qwertyuiopasdfghjklzxcvbnm',
+    'horizontalSpacing': '6.0',
+    'topLength': '10',
+    'middleLength': '9',
+  },
+  Layout.QWERTZ: <String, String>{
+    'layout': 'qwertzuiopasdfghjklyxcvbnm',
+    'horizontalSpacing': '6.0',
+    'topLength': '10',
+    'middleLength': '9',
+  },
+};
+
+var frenchConfig = {
+  Layout.QWERTY: <String, String>{
+    'layout': 'qwertyuiopasdfghjklzxcvbnm',
+    'horizontalSpacing': '6.0',
+    'topLength': '10',
+    'middleLength': '9',
+  },
+  Layout.AZERTY: <String, String>{
+    'layout': 'azertyuiopqsdfghjklmwxcvbn',
+    'horizontalSpacing': '6.0',
+    'topLength': '10',
+    'middleLength': '9',
+  },
+};


### PR DESCRIPTION
This is an easy way to add new languages or keyboard layouts to the package. ( resolves #1 )
To do that, you only need to modify the language.dart file. The following steps will illustrates how to do that.

1. Add the short name form of your new language to the `Language` enum.
```
enum Language {
  EN,
  FR,
  DE,
  <your new language>,
}
```
2. Add your layout name to the `Layout` enum if not present.
```
enum Layout {
  QWERTY,
  QWERTZ,
  AZERTY,
  <new layout>,
}
```
3. Create a new map variable called `<language name>Config`. The keys of this map will be the layouts from the `Layout` enum (e.g: Layout.QWERTY), and the values will be maps with types `<String, String>` that contain the core configuration. These latter maps must contain four fields o:
   1. `layout`: The full text layout of the keyboard.
   2. `horizontalSpacing`: A floating number which will represent the spaceing between each key. 
   3. `topLength`: The lenght of the top/first row of keys. In other words, the number of keys to display in the top row.
   4. `middleLength`: The number of keys in the middle row.

    (The bottom/last row will just take the remaining keys).

    example:
    ```
    var frenchConfig = {
      Layout.QWERTY: <String, String>{
        'layout': 'qwertyuiopasdfghjklzxcvbnm',
        'horizontalSpacing': '6.0',
        'topLength': '10',
        'middleLength': '9',
      },
      Layout.AZERTY: <String, String>{
        'layout': 'azertyuiopqsdfghjklmwxcvbn',
        'horizontalSpacing': '6.0',
        'topLength': '10',
        'middleLength': '9',
      },
    };
    ```
4. And finally your new language config map to the `languageConfig` map, with the key as the short language name from the `Language` enum.
```
var languageConfig = {
  Language.EN: englishConfig,
  Language.FR: frenchConfig,
  Language.DE: germanConfig,
  Language.<short language name>: <language name>Config,
};
```

As for the languages that require writing from right to left such as Arabic, this can be achieved externally by several ways. For example using the `textAlign` field in the `TextFormField` and setting it to `TextAlign.end`. There are few others, maybe cleaner, ways to achieve this and you can search for them on the web, Because that functionality is out of this package's scope.